### PR TITLE
VD-44 bug on Attractant active-term at detailed table

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1691,13 +1691,13 @@
                     <li>
                         {{if #data.brdColor}}
                             {{if #data.brdColor === '#000000'}}
-                                <span type="Attractants" value="{{attr:#data.name}}">
+                                <span type="Attractant" value="{{attr:#data.name}}">
                             {{else}}
-                                <span class="active-term" type="Attractants" value="{{attr:#data.name}}">
+                                <span class="active-term" type="Attractant" value="{{attr:#data.name}}">
                             {{/if}}
                                 <i class="fa  fa-circle" aria-hidden="true" style="color:{{attr:#data.brdColor}};"></i>
                         {{else}}
-                                <span class="active-term" type="Attractants" value="{{attr:#data.name}}">
+                                <span class="active-term" type="Attractant" value="{{attr:#data.name}}">
                         {{/if}}
                             {{>#data.name}}
                             </span>


### PR DESCRIPTION
I think this fixed the issue. After digging into all relevant parts, it was found that the issue was originated from single/plural use of the term defined in many other places. The solution was quite simple, though :(

I have applied this to my ash mapveu instance, so please test it:

https://dkwon.vectorbase.org/popbio-map/web/
