### PR TITLE
[VD-61] correcting actual link for tutorial icon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -358,7 +358,7 @@
                 <h3>
                     Usage tips
                     <a href="https://vectorbase.org/vectorbase/app/static-content/tutorials.html" target="_blank" class="title-tutorial-link">
-                        <img src="https://github.com/VEuPathDB/StaticContent/blob/master/documents/tutorials_orange_25.png">
+                        <img src="https://static-content.veupathdb.org/documents/tutorials_orange_25.png">
                         <span>Tutorials</span>
                     </a>
                 </h3>


### PR DESCRIPTION
I realized that Gloria's link was not actually working. After digging it, I could find the actual link to work so I have updated the link accordingly.